### PR TITLE
Don't clear figures when working from the terminal, only in notebook

### DIFF
--- a/fil_finder/filfind_class.py
+++ b/fil_finder/filfind_class.py
@@ -187,6 +187,16 @@ class fil_finder_2D(object):
         self.width_fits = {"Parameters": [], "Errors": [], "Names": None}
         self.rht_curvature = {"Median": [], "IQR": []}
         self.filament_arrays = {}
+        
+    @property
+    def pad_size(self):
+        return self._pad_size
+
+    @pad_size.setter
+    def pad_size(self, value):
+        if value <= 0:
+            raise ValueError("Pad size must be >0")
+        self._pad_size = value
 
     def create_mask(self, glob_thresh=None, adapt_thresh=None,
                     smooth_size=None, size_thresh=None, verbose=False,

--- a/fil_finder/filfind_class.py
+++ b/fil_finder/filfind_class.py
@@ -1267,6 +1267,36 @@ class fil_finder_2D(object):
                                     append=True)
         return self
 
+    @property
+    def mask_nopad(self):
+        return self.mask[self.pad_size:-self.pad_size,
+                         self.pad_size:-self.pad_size]
+
+    @property
+    def skeleton_nopad(self):
+        return self.skeleton[self.pad_size:-self.pad_size,
+                             self.pad_size:-self.pad_size]
+
+    @property
+    def skeleton_longpath_nopad(self):
+        return self.skeleton_longpath[self.pad_size:-self.pad_size,
+                                      self.pad_size:-self.pad_size]
+
+    @property
+    def flat_img_nopad(self):
+        return self.flat_img[self.pad_size:-self.pad_size,
+                             self.pad_size:-self.pad_size]
+
+    @property
+    def image_nopad(self):
+        return self.image[self.pad_size:-self.pad_size,
+                          self.pad_size:-self.pad_size]
+
+    @property
+    def medial_axis_distance_nopad(self):
+        return self.medial_axis_distance[self.pad_size:-self.pad_size,
+                                         self.pad_size:-self.pad_size]
+
     def save_fits(self, save_name=None, stamps=False, filename=None,
                   model_save=True):
         '''

--- a/fil_finder/filfind_class.py
+++ b/fil_finder/filfind_class.py
@@ -146,7 +146,8 @@ class fil_finder_2D(object):
 
         # Pad the image by the pad size. Avoids slicing difficulties
         # later on.
-        self.image = np.pad(self.image, self.pad_size, padwithnans)
+        if self.pad_size > 0:
+            self.image = np.pad(self.image, self.pad_size, padwithnans)
 
         # Make flattened image
         if flatten_thresh is None:

--- a/fil_finder/filfind_class.py
+++ b/fil_finder/filfind_class.py
@@ -76,12 +76,12 @@ class fil_finder_2D(object):
         This is the percentile of the data to mask off. All intensities below
         are cut off from being included in the filamentary structure.
     adapt_thresh : int, optional
-        This is the size of the patch used in the adaptive thresholding.
-        Bright structure is not very sensitive to the choice of patch size,
-        but faint structure is very sensitive. If None, the patch size is set
-        to twice the width of a typical filament (~0.2 pc). As the width of
-        filaments is somewhat ubiquitous, this patch size generally segments
-        all filamentary structure in a given image.
+        This is the size in pixels of the patch used in the adaptive
+        thresholding.  Bright structure is not very sensitive to the choice of
+        patch size, but faint structure is very sensitive. If None, the patch
+        size is set to twice the width of a typical filament (~0.2 pc). As the
+        width of filaments is somewhat ubiquitous, this patch size generally
+        segments all filamentary structure in a given image.
     distance : float, optional
         The distance to the region being examined (in pc). If None, the
         analysis is carried out in pixel and angular units. In this case,

--- a/fil_finder/filfind_class.py
+++ b/fil_finder/filfind_class.py
@@ -429,7 +429,8 @@ class fil_finder_2D(object):
                 p.savefig(os.path.join(self.save_name, self.save_name+"_mask.png"))
             if verbose:
                 p.show()
-            p.clf()
+            if in_ipynb():
+                p.clf()
 
         return self
 
@@ -493,7 +494,8 @@ class fil_finder_2D(object):
                                        self.save_name+"_initial_skeletons.png"))
             if verbose:
                 p.show()
-            p.clf()
+            if in_ipynb():
+                p.clf()
 
         return self
 
@@ -839,7 +841,8 @@ class fil_finder_2D(object):
                                                self.save_name+"_rht_"+str(n)+".png"))
                     if verbose:
                         p.show()
-                    p.clf()
+                    if in_ipynb():
+                        p.clf()
 
         return self
 
@@ -984,7 +987,8 @@ class fil_finder_2D(object):
                                            self.save_name+"_width_fit_"+str(n)+".png"))
                 if verbose:
                     p.show()
-                p.clf()
+                if in_ipynb():
+                    p.clf()
 
             # Final width check -- make sure length is longer than the width.
             # If it is, add the width onto the length since the adaptive

--- a/fil_finder/filfind_class.py
+++ b/fil_finder/filfind_class.py
@@ -420,6 +420,7 @@ class fil_finder_2D(object):
         if verbose or save_png:
             vmin = np.percentile(self.flat_img[np.isfinite(self.flat_img)], 20)
             vmax = np.percentile(self.flat_img[np.isfinite(self.flat_img)], 90)
+            p.clf()
             p.imshow(self.flat_img, interpolation=None, origin="lower",
                      cmap='binary', vmin=vmin, vmax=vmax)
             p.contour(self.mask, colors="r")
@@ -485,6 +486,7 @@ class fil_finder_2D(object):
         if verbose or save_png:  # For examining results of skeleton
             vmin = np.percentile(self.flat_img[np.isfinite(self.flat_img)], 20)
             vmax = np.percentile(self.flat_img[np.isfinite(self.flat_img)], 90)
+            p.clf()
             p.imshow(self.flat_img, interpolation=None, origin="lower",
                      cmap='binary', vmin=vmin, vmax=vmax)
             p.contour(self.skeleton, colors="r")
@@ -820,6 +822,7 @@ class fil_finder_2D(object):
                         np.abs(sevenfive - twofive + np.pi))
 
                 if verbose or save_png:
+                    p.clf()
                     ax1 = p.subplot(121, polar=True)
                     ax1.plot(2 * theta, R / R.max(), "kD")
                     ax1.fill_between(2 * theta, 0,
@@ -950,6 +953,7 @@ class fil_finder_2D(object):
                     print "Fit Errors: %s" % (fit_error)
                     print "Fit Type: %s" % (fit_type)
 
+                p.clf()
                 p.subplot(121)
                 p.plot(dist, radprof, "kD")
                 points = np.linspace(np.min(dist), np.max(dist), 2 * len(dist))

--- a/fil_finder/filfind_class.py
+++ b/fil_finder/filfind_class.py
@@ -565,9 +565,9 @@ class fil_finder_2D(object):
         Attributes
         ----------
         filament_arrays : list of numpy.ndarray
-                               Contains individual arrays of each skeleton
+            Contains individual arrays of each skeleton
         number_of_filaments : int
-                                   The number of individual filaments.
+            The number of individual filaments.
         array_offsets : list
             A list of coordinates for each filament array.This will
             be used to recombine the final skeletons into one array.
@@ -599,7 +599,7 @@ class fil_finder_2D(object):
         # Set the skeleton length threshold to some factor of the beam width
         if self.skel_thresh is None:
             self.skel_thresh = round(0.3 / self.imgscale)
-                # round( self.beamwidth * nbeam_lengths / self.imgscale)
+            # round( self.beamwidth * nbeam_lengths / self.imgscale)
         elif skel_thresh is not None:
             self.skel_thresh = skel_thresh
 
@@ -657,9 +657,9 @@ class fil_finder_2D(object):
         self.lengths = np.asarray(self.lengths)
 
         self.filament_arrays["final"] =\
-             make_final_skeletons(labeled_fil_arrays, interpts,
-                                  verbose=verbose, save_png=save_png,
-                                  save_name=self.save_name)
+            make_final_skeletons(labeled_fil_arrays, interpts,
+                                 verbose=verbose, save_png=save_png,
+                                 save_name=self.save_name)
 
         self.labelled_filament_arrays = labeled_fil_arrays
 

--- a/fil_finder/length.py
+++ b/fil_finder/length.py
@@ -397,8 +397,6 @@ def longest_path(edge_list, nodes, verbose=False, lengths=None,
     graphs = []
 
     for n in range(num):
-        if len(edge_list[n]) == 0:
-            continue
         G = nx.Graph()
         G.add_nodes_from(nodes[n])
         for i in edge_list[n]:

--- a/fil_finder/length.py
+++ b/fil_finder/length.py
@@ -397,6 +397,8 @@ def longest_path(edge_list, nodes, verbose=False, lengths=None,
     graphs = []
 
     for n in range(num):
+        if len(edge_list[n]) == 0:
+            continue
         G = nx.Graph()
         G.add_nodes_from(nodes[n])
         for i in edge_list[n]:

--- a/fil_finder/pixel_ident.py
+++ b/fil_finder/pixel_ident.py
@@ -66,8 +66,8 @@ def isolateregions(binary_array, size_threshold=0, pad_size=5,
         # Make an array shaped to the skeletons size and padded on each edge
         # the +1 is because, e.g., range(0, 5) only has 5 elements, but the
         # indices we're using are range(0, 6)
-        shapes = (x.max() - x.min() + 1 + 2 * pad_size,
-                  y.max() - y.min() + 1 + 2 * pad_size)
+        shapes = (x.max() - x.min() + 2 * pad_size,
+                  y.max() - y.min() + 2 * pad_size)
         eachfil = np.zeros(shapes)
         eachfil[x - x.min() + pad_size, y - y.min() + pad_size] = 1
         # Fill in small holes

--- a/fil_finder/pixel_ident.py
+++ b/fil_finder/pixel_ident.py
@@ -50,7 +50,7 @@ def isolateregions(binary_array, size_threshold=0, pad_size=5,
     # Label skeletons
     labels, num = nd.label(binary_array, eight_con())
 
-    # Remove skeletons which have less pixels than the threshold.
+    # Remove skeletons which have fewer pixels than the threshold.
     if size_threshold != 0:
         sums = nd.sum(binary_array, labels, range(1, num + 1))
         remove_fils = np.where(sums <= size_threshold)[0]
@@ -64,8 +64,10 @@ def isolateregions(binary_array, size_threshold=0, pad_size=5,
     for n in range(1, num + 1):
         x, y = np.where(labels == n)
         # Make an array shaped to the skeletons size and padded on each edge
-        shapes = (x.max() - x.min() + 2 * pad_size,
-                  y.max() - y.min() + 2 * pad_size)
+        # the +1 is because, e.g., range(0, 5) only has 5 elements, but the
+        # indices we're using are range(0, 6)
+        shapes = (x.max() - x.min() + 1 + 2 * pad_size,
+                  y.max() - y.min() + 1 + 2 * pad_size)
         eachfil = np.zeros(shapes)
         eachfil[x - x.min() + pad_size, y - y.min() + pad_size] = 1
         # Fill in small holes
@@ -553,6 +555,7 @@ def make_final_skeletons(labelisofil, inters, verbose=False, save_png=False,
                 Warning("Must give a save_name when save_png is enabled. No"
                         " plots will be created.")
 
+            p.clf()
             p.imshow(cleaned_array, origin='lower', interpolation='nearest')
 
             if save_png:
@@ -561,7 +564,8 @@ def make_final_skeletons(labelisofil, inters, verbose=False, save_png=False,
                                        save_name+"_final_skeleton_"+str(n)+".png"))
             if verbose:
                 p.show()
-            p.clf()
+            if in_ipynb():
+                p.clf()
 
     return filament_arrays
 

--- a/fil_finder/utilities.py
+++ b/fil_finder/utilities.py
@@ -140,7 +140,8 @@ def distance(x, x1, y, y1):
 
 def padwithzeros(vector, pad_width, iaxis, kwargs):
     vector[:pad_width[0]] = 0
-    vector[-pad_width[1]:] = 0
+    if pad_width[1] > 0:
+        vector[-pad_width[1]:] = 0
     return vector
 
 

--- a/fil_finder/utilities.py
+++ b/fil_finder/utilities.py
@@ -186,3 +186,13 @@ def try_mkdir(name):
 
     if not os.path.isdir(os.path.join(os.getcwd(), name)):
         os.mkdir(os.path.join(os.getcwd(), name))
+
+def in_ipynb():
+    try:
+        cfg = get_ipython().config
+        if cfg['IPKernelApp']['parent_appname'] == 'ipython-notebook':
+            return True
+        else:
+            return False
+    except NameError:
+        return False


### PR DESCRIPTION
The use of `p.clf()` after creating a figure immediately destroys the figure when used not in a notebook.  This works around that problem, though it creates some others.  The better practice is to clear the figure before plotting on it, not after.