### PR TITLE
Separate padding to skeleton only version

### DIFF
--- a/CHANGE.rst
+++ b/CHANGE.rst
@@ -6,3 +6,6 @@ New Features
 ^^^^^^^^^^^^
 
 - [#9] - Fix figure clearing in terminal
+
+- [#10] - Separate skeleton and image padding. Default to no image padding.
+          Clean-up with "no_mask" properties from [#9]

--- a/CHANGE.rst
+++ b/CHANGE.rst
@@ -8,4 +8,6 @@ New Features
 - [#9] - Fix figure clearing in terminal
 
 - [#10] - Separate skeleton and image padding. Default to no image padding.
-          Clean-up with "no_mask" properties from [#9]
+          Clean-up with "no_mask" properties from [#9]. Removed
+          "return_distance" option for the medial axis transform; it is always
+          used.

--- a/fil_finder/filfind_class.py
+++ b/fil_finder/filfind_class.py
@@ -352,11 +352,11 @@ class fil_finder_2D(object):
         else:
             nan_mask = np.logical_not(np.isnan(flat_copy))
 
+        # Remove nans in the copy
+        flat_copy[np.isnan(flat_copy)] = 0.0
+
         # Perform regridding
         if regrid:
-            # Remove nans in the copy
-            flat_copy[np.isnan(flat_copy)] = 0.0
-
             # Calculate the needed zoom to make the patch size ~40 pixels
             ratio = 40 / self.adapt_thresh
             # Round to the nearest factor of 2

--- a/fil_finder/filfind_class.py
+++ b/fil_finder/filfind_class.py
@@ -49,7 +49,9 @@ class fil_finder_2D(object):
         beamwidth.
     pad_size :  int, optional
         The size of the pad (in pixels) used to pad the individual
-        filament arrays. The default is set to 10 pixels.
+        filament arrays. By default this is disabled. **If the data continue
+        up to the edge of the image, padding should not be enabled as this
+        causes deviations in the mask around the edges!**
     skeleton_pad_size : int, optional
         Number of pixels to pad the individual skeleton arrays by. For
         the skeleton to graph conversion, the pad must always be greater

--- a/fil_finder/filfind_class.py
+++ b/fil_finder/filfind_class.py
@@ -1284,31 +1284,43 @@ class fil_finder_2D(object):
 
     @property
     def mask_nopad(self):
+        if self.pad_size == 0:
+            return self.mask
         return self.mask[self.pad_size:-self.pad_size,
                          self.pad_size:-self.pad_size]
 
     @property
     def skeleton_nopad(self):
+        if self.pad_size == 0:
+            return self.skeleton
         return self.skeleton[self.pad_size:-self.pad_size,
                              self.pad_size:-self.pad_size]
 
     @property
     def skeleton_longpath_nopad(self):
+        if self.pad_size == 0:
+            return self.skeleton_longpath
         return self.skeleton_longpath[self.pad_size:-self.pad_size,
                                       self.pad_size:-self.pad_size]
 
     @property
     def flat_img_nopad(self):
+        if self.pad_size == 0:
+            self.flat_img
         return self.flat_img[self.pad_size:-self.pad_size,
                              self.pad_size:-self.pad_size]
 
     @property
     def image_nopad(self):
+        if self.pad_size == 0:
+            return self.image
         return self.image[self.pad_size:-self.pad_size,
                           self.pad_size:-self.pad_size]
 
     @property
     def medial_axis_distance_nopad(self):
+        if self.pad_size == 0:
+            return self.medial_axis_distance
         return self.medial_axis_distance[self.pad_size:-self.pad_size,
                                          self.pad_size:-self.pad_size]
 

--- a/fil_finder/filfind_class.py
+++ b/fil_finder/filfind_class.py
@@ -513,7 +513,7 @@ class fil_finder_2D(object):
         return self
 
     def analyze_skeletons(self, relintens_thresh=0.2, nbeam_lengths=5,
-                          branch_nbeam_lengths=3,
+                          branch_nbeam_lengths=3, skel_pad=10,
                           skel_thresh=None, branch_thresh=None,
                           verbose=False, save_png=False):
         '''
@@ -563,6 +563,10 @@ class fil_finder_2D(object):
         branch_nbeam_lengths : float or int, optional
             Sets the minimum branch length based on the number of beam
             sizes specified.
+        skel_pad : int, optional
+            Number of pixels to pad the individual skeleton arrays by. For
+            the skeleton to graph conversion, the pad must always be greater
+            then 0.
         skel_thresh : float, optional
             Manually set the minimum skeleton threshold. Overrides all
             previous settings.
@@ -622,7 +626,7 @@ class fil_finder_2D(object):
 
         isolated_filaments, num, offsets = \
             isolateregions(self.skeleton, size_threshold=self.skel_thresh,
-                           pad_size=self.pad_size)
+                           pad_size=skel_pad)
         self.number_of_filaments = num
         self.array_offsets = offsets
 
@@ -682,12 +686,12 @@ class fil_finder_2D(object):
         self.skeleton = \
             recombine_skeletons(self.filament_arrays["final"],
                                 self.array_offsets, self.image.shape,
-                                self.pad_size, verbose=True)
+                                skel_pad, verbose=True)
 
         self.skeleton_longpath = \
             recombine_skeletons(self.filament_arrays["long path"],
                                 self.array_offsets, self.image.shape,
-                                self.pad_size, verbose=True)
+                                skel_pad, verbose=True)
 
         return self
 

--- a/fil_finder/filfind_class.py
+++ b/fil_finder/filfind_class.py
@@ -461,7 +461,7 @@ class fil_finder_2D(object):
 
         return self
 
-    def medskel(self, return_distance=True, verbose=False, save_png=False):
+    def medskel(self, verbose=False, save_png=False):
         '''
 
         This function performs the medial axis transform (skeletonization)
@@ -476,9 +476,6 @@ class fil_finder_2D(object):
 
         Parameters
         ----------
-        return_distance : bool, optional
-            This sets whether the distance transform is returned from
-            skimage.morphology.medial_axis.
         verbose : bool, optional
             Enables plotting.
         save_png : bool, optional
@@ -492,22 +489,17 @@ class fil_finder_2D(object):
             The distance transform used to create the skeletons.
         '''
 
-        if return_distance:
-            self.skeleton, self.medial_axis_distance = medial_axis(
-                self.mask, return_distance=return_distance)
-            self.medial_axis_distance = self.medial_axis_distance * \
-                self.skeleton
-            # Delete connection smaller than 2 pixels wide. Such a small
-            # connection is more likely to be from limited pixel resolution
-            # rather than actual structure.
-            width_threshold = 1
-            narrow_pts = np.where(self.medial_axis_distance < width_threshold)
-            self.skeleton[narrow_pts] = 0  # Eliminate narrow connections
-            self.medial_axis_distance[narrow_pts] = 0
-
-        else:
-            self.skeleton = medial_axis(self.mask)
-            self.medial_axis_skeleton = None
+        self.skeleton, self.medial_axis_distance = \
+            medial_axis(self.mask, return_distance=return_distance)
+        self.medial_axis_distance = \
+            self.medial_axis_distance * self.skeleton
+        # Delete connection smaller than 2 pixels wide. Such a small
+        # connection is more likely to be from limited pixel resolution
+        # rather than actual structure.
+        width_threshold = 1
+        narrow_pts = np.where(self.medial_axis_distance < width_threshold)
+        self.skeleton[narrow_pts] = 0  # Eliminate narrow connections
+        self.medial_axis_distance[narrow_pts] = 0
 
         if verbose or save_png:  # For examining results of skeleton
             vmin = np.percentile(self.flat_img[np.isfinite(self.flat_img)], 20)

--- a/fil_finder/filfind_class.py
+++ b/fil_finder/filfind_class.py
@@ -1074,7 +1074,7 @@ class fil_finder_2D(object):
 
         return self
 
-    def filament_model(self, max_radius=25):
+    def filament_model(self, max_radius=25, use_nopad=True):
         '''
         Returns a model of the diffuse filamentary network based
         on the radial profiles.
@@ -1083,6 +1083,9 @@ class fil_finder_2D(object):
         ----------
         max_radius : int, optional
             Number of pixels to extend profiles to.
+        use_nopad : bool, optional
+            Returns the unpadded image size when enabled. Enabled by
+            default.
 
         Returns
         -------
@@ -1097,9 +1100,14 @@ class fil_finder_2D(object):
         params = self.width_fits['Parameters']
         scale = self.imgscale
 
+        if use_nopad:
+            skel_array = self.skeleton_nopad
+        else:
+            skel_array = self.skeleton
+
         # Create the distance transforms
         all_fils = dist_transform(self.filament_arrays["final"],
-                                  self.skeleton)[0]
+                                  skel_array)[0]
 
         model_image = np.zeros(all_fils.shape)
 

--- a/fil_finder/filfind_class.py
+++ b/fil_finder/filfind_class.py
@@ -1380,16 +1380,12 @@ class fil_finder_2D(object):
             str(self.adapt_thresh) + " pixels"
         new_hdr["COMMENT"] = "Original file name: " + filename
 
-        # Remove padding
-        mask = self.mask[self.pad_size:-self.pad_size,
-                         self.pad_size:-self.pad_size]
-
         try_mkdir(self.save_name)
 
         # Save mask
         fits.writeto(os.path.join(self.save_name,
                                   "".join([save_name, "_mask.fits"])),
-                     mask.astype(">i2"), new_hdr)
+                     self.mask_nopad.astype(">i2"), new_hdr)
 
         # Save skeletons. Includes final skeletons and the longest paths.
         try:
@@ -1406,17 +1402,11 @@ class fil_finder_2D(object):
 
         # Final Skeletons - create labels which match up with table output
 
-        # Remove padding
-        skeleton = self.skeleton[self.pad_size:-self.pad_size,
-                                 self.pad_size:-self.pad_size]
-        skeleton_long = self.skeleton_longpath[self.pad_size:-self.pad_size,
-                                               self.pad_size:-self.pad_size]
-
-        labels = nd.label(skeleton, eight_con())[0]
+        labels = nd.label(self.skeleton_nopad, eight_con())[0]
         hdu_skel.append(fits.PrimaryHDU(labels.astype(">i2"), header=new_hdr))
 
         # Longest Paths
-        labels_lp = nd.label(skeleton_long, eight_con())[0]
+        labels_lp = nd.label(self.skeleton_longpath_nopad, eight_con())[0]
         hdu_skel.append(fits.PrimaryHDU(labels_lp.astype(">i2"),
                                         header=new_hdr))
 

--- a/fil_finder/filfind_class.py
+++ b/fil_finder/filfind_class.py
@@ -492,7 +492,7 @@ class fil_finder_2D(object):
         '''
 
         self.skeleton, self.medial_axis_distance = \
-            medial_axis(self.mask, return_distance=return_distance)
+            medial_axis(self.mask, return_distance=True)
         self.medial_axis_distance = \
             self.medial_axis_distance * self.skeleton
         # Delete connection smaller than 2 pixels wide. Such a small

--- a/fil_finder/filfind_class.py
+++ b/fil_finder/filfind_class.py
@@ -204,17 +204,14 @@ class fil_finder_2D(object):
 
     @property
     def skeleton_pad_size(self):
-        return self._pad_size
+        return self._skeleton_pad_size
 
     @skeleton_pad_size.setter
     def skeleton_pad_size(self, value):
         if value < 0:
             raise ValueError("Skeleton pad size must be >0")
-        self._pad_size = value
+        self._skeleton_pad_size = value
 
-    # @property
-    # def pad_size_difference(self):
-    #     return self._pad_size - self._skeleton_pad_size
 
     def create_mask(self, glob_thresh=None, adapt_thresh=None,
                     smooth_size=None, size_thresh=None, verbose=False,
@@ -377,7 +374,7 @@ class fil_finder_2D(object):
 
         # Set the border to zeros for the adaptive thresholding. Avoid border
         # effects.
-        if zero_border:
+        if zero_border and self.pad_size > 0:
             smooth_img[:self.pad_size*ratio+1, :] = 0.0
             smooth_img[-self.pad_size*ratio-1:, :] = 0.0
             smooth_img[:, :self.pad_size*ratio+1] = 0.0
@@ -412,10 +409,10 @@ class fil_finder_2D(object):
 
         mask_objs, num, corners = \
             isolateregions(cleaned, fill_hole=True, rel_size=fill_hole_size,
-                           morph_smooth=True)
+                           morph_smooth=True, pad_size=self.skeleton_pad_size)
         self.mask = recombine_skeletons(mask_objs,
                                         corners, self.image.shape,
-                                        self.pad_size, verbose=True)
+                                        self.skeleton_pad_size, verbose=True)
 
         # WARNING!! Setting some image values to 0 to avoid negative weights.
         # This may cause issues, however it will allow for proper skeletons

--- a/fil_finder/filfind_class.py
+++ b/fil_finder/filfind_class.py
@@ -1481,11 +1481,7 @@ class fil_finder_2D(object):
                                          save_name+"_object_"+str(n+1)+".fits"))
 
         if model_save:
-            model = self.filament_model()
-
-            # Remove the padding
-            model = model[self.pad_size:-self.pad_size,
-                          self.pad_size:-self.pad_size]
+            model = self.filament_model(use_nopad=True)
 
             model_hdr = new_hdr.copy()
 

--- a/fil_finder/tests/test_whole.py
+++ b/fil_finder/tests/test_whole.py
@@ -16,7 +16,8 @@ class Test_FilFinder(TestCase):
 
         test1 = fil_finder_2D(img, hdr, 10.0, flatten_thresh=95,
                               distance=260, size_thresh=430,
-                              glob_thresh=20, save_name="test1")
+                              glob_thresh=20, save_name="test1",
+                              pad_size=10, skeleton_pad_size=10)
 
         test1.create_mask(border_masking=False)
         test1.medskel()
@@ -52,7 +53,8 @@ class Test_FilFinder(TestCase):
 
         test2 = fil_finder_2D(img, hdr, 10.0, flatten_thresh=95,
                               distance=260, size_thresh=430,
-                              glob_thresh=20, save_name="test2")
+                              glob_thresh=20, save_name="test2",
+                              pad_size=10, skeleton_pad_size=10)
 
         test2.create_mask(border_masking=False)
         test2.medskel()

--- a/fil_finder/tests/test_whole.py
+++ b/fil_finder/tests/test_whole.py
@@ -25,6 +25,8 @@ class Test_FilFinder(TestCase):
         test1.find_widths()
         test1.compute_filament_brightness()
 
+        assert test1.number_of_filaments == len(table1["Lengths"])
+
         for i, param in enumerate(test1.width_fits["Names"]):
             assert np.allclose(test1.width_fits["Parameters"][:, i],
                                np.asarray(table1[param]))
@@ -58,6 +60,8 @@ class Test_FilFinder(TestCase):
         test2.exec_rht(branches=False)
         test2.find_widths()
         test2.compute_filament_brightness()
+
+        assert test2.number_of_filaments == len(table2["Lengths"])
 
         for i, param in enumerate(test2.width_fits["Names"]):
             assert np.allclose(test2.width_fits["Parameters"][:, i],


### PR DESCRIPTION
Padding currently is used for the entire image and the separate skeleton arrays. These don't need to be the same, but the skeleton padding must always be enabled.