### PR TITLE
Remove graphviz plotting

### DIFF
--- a/CHANGE.rst
+++ b/CHANGE.rst
@@ -2,8 +2,7 @@
 1.3 (unreleased)
 ----------------
 
-New Features
-^^^^^^^^^^^^
+- [#16] - Remove graphviz drawing of graphs
 
 
 1.2.1 (2015-10-30): Patch for Numpy 1.10

--- a/fil_finder/filfind_class.py
+++ b/fil_finder/filfind_class.py
@@ -651,8 +651,7 @@ class fil_finder_2D(object):
                          verbose=verbose,
                          save_png=save_png,
                          save_name=self.save_name,
-                         skeleton_arrays=labeled_fil_arrays,
-                         lengths=self.branch_properties["length"])
+                         skeleton_arrays=labeled_fil_arrays)
 
         updated_lists = \
             prune_graph(G, nodes, edge_list, max_path, labeled_fil_arrays,

--- a/fil_finder/length.py
+++ b/fil_finder/length.py
@@ -347,7 +347,7 @@ def pre_graph(labelisofil, branch_properties, interpts, ends):
     return edge_list, nodes
 
 
-def longest_path(edge_list, nodes, verbose=False, lengths=None,
+def longest_path(edge_list, nodes, verbose=False,
                  skeleton_arrays=None, save_png=False, save_name=None):
     '''
     Takes the output of pre_graph and runs the shortest path algorithm.
@@ -363,12 +363,7 @@ def longest_path(edge_list, nodes, verbose=False, lengths=None,
         been separated as they are labeled differently.
 
     verbose : bool, optional
-        If True, enables the plotting of the graph. *Recommend pygraphviz
-        be installed for best results.*
-
-    lengths : list, optional
-        Contains the lengths of each branch. Required only for graphviz
-        plotting of the graphs.
+        If True, enables the plotting of the graph.
 
     skeleton_arrays : list, optional
         List of the skeleton arrays. Required when verbose=True.
@@ -434,10 +429,7 @@ def longest_path(edge_list, nodes, verbose=False, lengths=None,
 
                 p.subplot(1, 2, 2)
                 elist = [(u, v) for (u, v, d) in G.edges(data=True)]
-                try:
-                    pos = nx.graphviz_layout(G)  # , arg=str(lengths[n]))
-                except ImportError:
-                    pos = nx.spring_layout(G)
+                pos = nx.spring_layout(G)
                 nx.draw_networkx_nodes(G, pos, node_size=200)
                 nx.draw_networkx_edges(G, pos, edgelist=elist, width=2)
                 nx.draw_networkx_labels(


### PR DESCRIPTION
As noted in #14 , calls to graphviz through networkx can be troublesome. Graphs are now plotted using the spring layout of networkx.