### PR TITLE
Generalize cut params

### DIFF
--- a/CHANGE.rst
+++ b/CHANGE.rst
@@ -2,6 +2,8 @@
 1.3 (unreleased)
 ----------------
 
+- [#19] - Generalize radial profile cutting.
+
 - [#17] - Allow longest path skeletons to be used for width fitting. Also fixed a fitting bug where bad guesses at the initial width led to terrible fits. Fixed a bug in the non-parametric width where the target width was not using e^-0.5 of the maximum.
 
 - [#16] - Remove graphviz drawing of graphs

--- a/fil_finder/filfind_class.py
+++ b/fil_finder/filfind_class.py
@@ -869,7 +869,8 @@ class fil_finder_2D(object):
         return self
 
     def find_widths(self, fit_model=gauss_model, try_nonparam=True,
-                    use_longest_paths=False, verbose=False, save_png=False):
+                    use_longest_paths=False, verbose=False, save_png=False,
+                    **kwargs):
         '''
 
         The final step of the algorithm is to find the widths of each
@@ -931,7 +932,8 @@ class fil_finder_2D(object):
             dist, radprof, weights, unbin_dist, unbin_radprof = \
                 radial_profile(self.image, dist_transform_all,
                                dist_transform_separate[n],
-                               self.array_offsets[n], self.imgscale)
+                               self.array_offsets[n], self.imgscale,
+                               **kwargs)
 
             if fit_model == cyl_model:
                 if self.freq is None:

--- a/fil_finder/width.py
+++ b/fil_finder/width.py
@@ -415,18 +415,25 @@ def radial_profile(img, dist_transform_all, dist_transform_sep, offsets,
     for i in range(len(x)):
         # Check overall distance transform to make sure pixel belongs to proper
         # filament
-        if img[x_full[i], y_full[i]]!=0.0 and np.isfinite(img[x_full[i], y_full[i]]):
-            if dist_transform_sep[x[i], y[i]] <= dist_transform_all[x_full[i], y_full[i]]:
-                width_value.append(img[x_full[i], y_full[i]])
-                width_distance.append(dist_transform_sep[x[i], y[i]])
+        img_val = img[x_full[i], y_full[i]]
+        sep_dist = dist_transform_sep[x[i], y[i]]
+        glob_dist = dist_transform_all[x_full[i], y_full[i]]
+        if img_val != 0.0 and np.isfinite(img_val):
+            if sep_dist <= glob_dist:
+                width_value.append(img_val)
+                width_distance.append(sep_dist)
             else:
                 nonlocalpix.append([x[i], y[i], x_full[i], y_full[i]])
 
-    if pad_to_distance>0.0 and np.max(width_distance)*img_scale < pad_to_distance:
-        pad = int(
-            (pad_to_distance - np.max(width_distance) * img_scale) * img_scale ** -1)
+    need_pad = np.max(width_distance)*img_scale < pad_to_distance
+
+    if pad_to_distance > 0.0 and need_pad:
+        pad_dist = pad_to_distance - np.max(width_distance) * img_scale
+        pad = int(pad_dist * img_scale ** -1)
         for pix in nonlocalpix:
-            if dist_transform_sep[pix[0], pix[1]] <= dist_transform_all[pix[2], pix[3]] + pad:
+            sep_dist = dist_transform_sep[pix[0], pix[1]]
+            glob_dist = dist_transform_all[pix[2], pix[3]]
+            if sep_dist <= glob_dist + pad:
                 width_value.append(img[pix[2], pix[3]])
                 width_distance.append(dist_transform_sep[pix[0], pix[1]])
 


### PR DESCRIPTION
Some parameters for cutting the profiles were not generalized. They can now be set by passing the `auto_cut_kwargs` into `fil_finder_2D.find_widths`. All parameters are assumed to be in pc. Units generalization coming soon...