### PR TITLE
Fix lengths from skimage updates

### DIFF
--- a/CHANGE.rst
+++ b/CHANGE.rst
@@ -1,6 +1,7 @@
 
 1.3 (unreleased)
 ----------------
+- [#23] - Fix error in length when using new version of skimage.
 - [#22] - Fix FWHM error calculation.
 
 - [#21] - Enforce odd patch sizes for adaptive thresholding. New unit test data to reflect the slight change from using an odd patch size in the test cases.

--- a/fil_finder/length.py
+++ b/fil_finder/length.py
@@ -58,7 +58,7 @@ def skeleton_length(skeleton):
     '''
 
     # 4-connected labels
-    four_labels = me.label(skeleton, 4, background=0)
+    four_labels = nd.label(skeleton)[0]
 
     four_sizes = nd.sum(skeleton, four_labels, range(np.max(four_labels) + 1))
 
@@ -78,13 +78,13 @@ def skeleton_length(skeleton):
     # Remaining pixels are only 8-connected
     # Lengths is same as before, multiplied by sqrt(2)
 
-    eight_labels = me.label(skel_copy, 8, background=0)
+    eight_labels = nd.label(skel_copy, eight_con())[0]
 
     eight_sizes = nd.sum(
         skel_copy, eight_labels, range(np.max(eight_labels) + 1))
 
     eight_length = (
-        (np.sum(eight_sizes) - 1) - np.max(eight_labels)) * np.sqrt(2)
+        np.sum(eight_sizes) - np.max(eight_labels)) * np.sqrt(2)
 
     # If there are no 4-connected pixels, we don't need the hit-miss portion.
     if four_length == 0.0:

--- a/fil_finder/length.py
+++ b/fil_finder/length.py
@@ -12,7 +12,6 @@ import operator
 import string
 import copy
 import os
-from skimage import measure as me
 
 # Create 4 to 8-connected elements to use with binary hit-or-miss
 struct1 = np.array([[1, 0, 0],


### PR DESCRIPTION
Lengths are incorrect when using the newest release of skimage. Their old label function defined -1 as the background; the new one uses 0 instead as in `scipy.ndimage`. While it likely won't be changed again, I've switched to using `scipy.ndimage` only. 