### PR TITLE
Header as an optional input

### DIFF
--- a/CHANGE.rst
+++ b/CHANGE.rst
@@ -1,6 +1,7 @@
 
 1.3 (unreleased)
 ----------------
+- [#24] - Allow for `fits.PrimaryHDUs` to be given. Headers are now optional; units default to pixel units in this case. `beamwidth` and `distance` are expected to be `astropy.units.Quantity` objects with appropriate units!
 - [#23] - Fix error in length when using new version of skimage.
 - [#22] - Fix FWHM error calculation.
 

--- a/fil_finder/filfind_class.py
+++ b/fil_finder/filfind_class.py
@@ -246,7 +246,7 @@ class fil_finder_2D(object):
                             try:
                                 self.beamwidth = \
                                     (width.to(u.arcsec).value / 206265.) * \
-                                    distance
+                                    distance.value
                             except u.UnitConversionError:
                                 raise u.UnitConversionError("Cannot convert the "
                                                             "given beamwidth in "

--- a/fil_finder/filfind_class.py
+++ b/fil_finder/filfind_class.py
@@ -1438,7 +1438,13 @@ class fil_finder_2D(object):
             filename = save_name
 
         # Create header based off of image header.
-        new_hdr = deepcopy(self.header)
+        if self.header is not None:
+            new_hdr = deepcopy(self.header)
+        else:
+            new_hdr = fits.Header()
+            new_hdr["NAXIS"] = 2
+            new_hdr["NAXIS1"] = self.mask_nopad.shape[1]
+            new_hdr["NAXIS2"] = self.mask_nopad.shape[0]
 
         try:  # delete the original history
             del new_hdr["HISTORY"]
@@ -1528,7 +1534,14 @@ class fil_finder_2D(object):
                                        ylow:yhigh]
 
                 # ADD IN SOME HEADERS!
-                prim_hdr = deepcopy(self.header)
+                if self.header is not None:
+                    prim_hdr = deepcopy(self.header)
+                else:
+                    prim_hdr = fits.Header()
+                    prim_hdr["NAXIS"] = 2
+                    prim_hdr["NAXIS1"] = img_stamp.shape[1]
+                    prim_hdr["NAXIS2"] = img_stamp.shape[0]
+
                 prim_hdr["COMMENT"] = "Outputted from fil_finder."
                 prim_hdr["COMMENT"] = \
                     "Extent in original array: (" + \

--- a/fil_finder/filfind_class.py
+++ b/fil_finder/filfind_class.py
@@ -218,7 +218,7 @@ class fil_finder_2D(object):
                     else:
                         self.beamwidth = (beamwidth.to(u.deg) /
                                           (self.header["CDELT2"] * u.deg)).value
-                    self.beamwidth = beamwidth
+                    self.beamwidth = beamwidth.value /FWHM_FACTOR
                     self.imgscale = 1.0
                     self.pixel_unit_flag = True
                 else:

--- a/fil_finder/filfind_class.py
+++ b/fil_finder/filfind_class.py
@@ -39,8 +39,10 @@ class fil_finder_2D(object):
     image : numpy.ndarray or astropy.io.fits.PrimaryHDU
         A 2D array of the data to be analyzed. If a FITS HDU is passed, the
         header is automatically loaded.
-    hdr : FITS header
-        The header from fits file containing the data.
+    header : FITS header, optional
+        The header from fits file containing the data. If no header is provided,
+        and it could not be loaded from ``image``, all results will be returned
+        in pixel units.
     beamwidth : float or astropy.units.Quantity, optional
         The FWHM beamwidth with an appropriately attached unit. By default,
         the beam is read from a provided header. If the beam cannot be read

--- a/fil_finder/filfind_class.py
+++ b/fil_finder/filfind_class.py
@@ -214,7 +214,7 @@ class fil_finder_2D(object):
                 if distance is None:
                     Warning("No distance given. Results will be in pixel units.")
                     if beamwidth.unit == u.pix:
-                        self.beamwidth = beamwidth.value
+                        self.beamwidth = beamwidth
                     else:
                         self.beamwidth = (beamwidth.to(u.deg) /
                                           (self.header["CDELT2"] * u.deg)).value

--- a/fil_finder/filfind_class.py
+++ b/fil_finder/filfind_class.py
@@ -1,13 +1,5 @@
 # Licensed under an MIT open source license - see LICENSE
 
-from cores import *
-from length import *
-from pixel_ident import *
-from utilities import *
-from width import *
-from rollinghough import rht
-from analysis import Analysis
-
 import numpy as np
 import matplotlib.pyplot as p
 import scipy.ndimage as nd
@@ -23,6 +15,14 @@ from copy import deepcopy
 import os
 import time
 import warnings
+
+from .cores import *
+from .length import *
+from .pixel_ident import *
+from .utilities import *
+from .width import *
+from .rollinghough import rht
+from .analysis import Analysis
 
 
 class fil_finder_2D(object):

--- a/fil_finder/io_funcs.py
+++ b/fil_finder/io_funcs.py
@@ -1,0 +1,45 @@
+# Licensed under an MIT open source license - see LICENSE
+
+from astropy.io.fits import PrimaryHDU
+# from spectral_cube.lower_dimensional_structures import LowerDimensionalObject
+import numpy as np
+
+
+allowed_types = ["numpy.ndarray", "astropy.io.fits.PrimaryHDU"]  # ,
+                 # "spectral_cube.LowerDimensionalObject"]
+
+def input_data(data):
+    '''
+    Accept a variety of input data forms and return those expected by the
+    various statistics.
+
+    Parameters
+    ----------
+    data : astropy.io.fits.PrimaryHDU, SpectralCube,
+           spectral_cube.LowerDimensionalObject, np.ndarray or a tuple/list
+           with the data and the header
+        Data to be used with a given statistic or distance metric. no_header
+        must be enabled when passing only an array in.
+
+    Returns
+    -------
+    ouput_data : tuple or np.ndarray
+        A tuple containing the data and the header. Or an array when no_header
+        is enabled.
+    '''
+
+    if isinstance(data, PrimaryHDU):
+        output_data = {"data": data.data.squeeze(), "header": data.header}
+
+    # elif isinstance(data, LowerDimensionalObject):
+    #     output_data = (data.value, data.header)
+    elif isinstance(data, np.ndarray):
+        output_data = {"data": data.squeeze()}
+    else:
+        raise TypeError("Input data is not of an accepted form:"
+                        " astropy.io.fits.PrimaryHDU, np.ndarray.")
+
+    if len(output_data["data"].shape) != 2:
+        raise TypeError("Data must be 2D. Please re-check the inputs.")
+
+    return output_data

--- a/fil_finder/tests/test_init.py
+++ b/fil_finder/tests/test_init.py
@@ -1,0 +1,78 @@
+# Licensed under an MIT open source license - see LICENSE
+
+from unittest import TestCase
+
+import numpy as np
+import numpy.testing as npt
+import astropy.units as u
+
+from fil_finder import fil_finder_2D
+
+from _testing_data import *
+
+FWHM_FACTOR = 2 * np.sqrt(2 * np.log(2.))
+
+
+class Test_FilFinder_Units(TestCase):
+
+    def test_with_distance(self):
+
+        distance = 260*u.pc
+        beamwidth = 10.0*u.arcsec
+        # Divide by FWHM factor
+        width = beamwidth / (2*np.sqrt(2*np.log(2)))
+
+        test1 = fil_finder_2D(img, header=hdr, beamwidth=beamwidth,
+                              flatten_thresh=95,
+                              distance=distance, size_thresh=430,
+                              glob_thresh=20, save_name="test1")
+
+        imgscale = hdr['CDELT2'] * \
+            (np.pi / 180.0) * distance.to(u.pc).value
+        beamwidth = (width.to(u.arcsec).value / 206265.) * distance.value
+        npt.assert_equal(test1.imgscale, imgscale)
+        npt.assert_equal(test1.beamwidth, beamwidth)
+
+    def test_without_distance(self):
+
+        beamwidth = 10.0*u.arcsec
+
+        test1 = fil_finder_2D(img, header=hdr, beamwidth=beamwidth,
+                              flatten_thresh=95,
+                              distance=None, size_thresh=430,
+                              glob_thresh=20, save_name="test1")
+
+        beamwidth = (beamwidth.to(u.deg) /
+                     (hdr["CDELT2"] * u.deg)) / FWHM_FACTOR
+        imgscale = 1.0
+        npt.assert_equal(test1.imgscale, imgscale)
+        npt.assert_equal(test1.beamwidth, beamwidth.value)
+
+    def test_without_header(self):
+
+        beamwidth = 10.0*u.pix
+        distance = 260*u.pc
+
+        test1 = fil_finder_2D(img, header=None, beamwidth=beamwidth,
+                              flatten_thresh=95,
+                              distance=distance, size_thresh=430,
+                              glob_thresh=20, save_name="test1")
+
+        beamwidth = beamwidth / FWHM_FACTOR
+        imgscale = 1.0
+        npt.assert_equal(test1.imgscale, imgscale)
+        npt.assert_equal(test1.beamwidth, beamwidth.value)
+
+    def test_without_header_distance(self):
+
+        beamwidth = 10.0*u.pix
+
+        test1 = fil_finder_2D(img, header=None, beamwidth=beamwidth,
+                              flatten_thresh=95,
+                              distance=None, size_thresh=430,
+                              glob_thresh=20, save_name="test1")
+
+        beamwidth = beamwidth / FWHM_FACTOR
+        imgscale = 1.0
+        npt.assert_equal(test1.imgscale, imgscale)
+        npt.assert_equal(test1.beamwidth, beamwidth.value)

--- a/fil_finder/tests/test_init.py
+++ b/fil_finder/tests/test_init.py
@@ -76,3 +76,19 @@ class Test_FilFinder_Units(TestCase):
         imgscale = 1.0
         npt.assert_equal(test1.imgscale, imgscale)
         npt.assert_equal(test1.beamwidth, beamwidth.value)
+
+    def test_header_beam(self):
+
+        beam_hdr = hdr.copy()
+        # It only looks for BMAJ at the moment.
+        beam_hdr["BMAJ"] = 10.0
+
+        test1 = fil_finder_2D(img, header=beam_hdr, beamwidth=None,
+                              flatten_thresh=95,
+                              distance=None, size_thresh=430,
+                              glob_thresh=20, save_name="test1")
+
+        beamwidth = (10.0 * u.deg / (hdr["CDELT2"] * u.deg)) / FWHM_FACTOR
+        imgscale = 1.0
+        npt.assert_equal(test1.imgscale, imgscale)
+        npt.assert_equal(test1.beamwidth, beamwidth.value)

--- a/fil_finder/tests/test_input_types.py
+++ b/fil_finder/tests/test_input_types.py
@@ -1,0 +1,47 @@
+# Licensed under an MIT open source license - see LICENSE
+
+from unittest import TestCase
+
+import numpy as np
+import numpy.testing as npt
+import astropy.units as u
+from astropy.io.fits import PrimaryHDU
+
+from fil_finder.io_funcs import input_data
+
+from _testing_data import *
+
+FWHM_FACTOR = 2 * np.sqrt(2 * np.log(2.))
+
+
+class Test_FilFinder_Input_Types(TestCase):
+
+    def test_array_input(self):
+
+        output = input_data(img)
+
+        npt.assert_equal(img, output["data"])
+
+    def test_HDU_input(self):
+
+        hdu = PrimaryHDU(img, header=hdr)
+
+        output = input_data(hdu)
+
+        npt.assert_equal(img, output["data"])
+        npt.assert_equal(hdr, output["header"])
+
+    def test_3D_input(self):
+
+        try:
+            output = input_data(np.ones((3,) * 3))
+        except Exception, e:
+            assert isinstance(e, TypeError)
+
+    def test_3D_squeezable_input(self):
+
+        output = input_data(np.ones((3,3,1)))
+
+        npt.assert_equal(np.ones((3,3)), output["data"])
+
+

--- a/fil_finder/tests/test_whole.py
+++ b/fil_finder/tests/test_whole.py
@@ -4,6 +4,7 @@ from unittest import TestCase
 
 import numpy as np
 import numpy.testing as npt
+import astropy.units as u
 
 from fil_finder import fil_finder_2D
 
@@ -14,8 +15,9 @@ class Test_FilFinder(TestCase):
 
     def test_with_rht_branches(self):
 
-        test1 = fil_finder_2D(img, hdr, 10.0, flatten_thresh=95,
-                              distance=260, size_thresh=430,
+        test1 = fil_finder_2D(img, header=hdr, beamwidth=10.0*u.arcsec,
+                              flatten_thresh=95,
+                              distance=260*u.pc, size_thresh=430,
                               glob_thresh=20, save_name="test1")
 
         test1.create_mask(border_masking=False)
@@ -50,8 +52,9 @@ class Test_FilFinder(TestCase):
     def test_without_rht_branches(self):
         # Non-branches
 
-        test2 = fil_finder_2D(img, hdr, 10.0, flatten_thresh=95,
-                              distance=260, size_thresh=430,
+        test2 = fil_finder_2D(img, header=hdr, beamwidth=10.0*u.arcsec,
+                              flatten_thresh=95,
+                              distance=260*u.pc, size_thresh=430,
                               glob_thresh=20, save_name="test2")
 
         test2.create_mask(border_masking=False)


### PR DESCRIPTION
Makes three significant changes:
- `header` and `beamwidth` are now keywords args. If no header is given, all results will be in pixel units.
- `image` can now be either a `np.ndarray` (as before), or an `astropy.io.fits.PrimaryHDU`. In the latter case, the header is automatically loaded.
- `beamwidth`and `distance` are now expected to be an `astropy.units.Quantity` with an appropriate unit. If no unit is given, `beamwidth` is assumed to be in **pixels**, before it was assumed to be in **arcseconds**! Units on `distance` are assumed to be in `pc`.