### PR TITLE
Handle wcs

### DIFF
--- a/CHANGE.rst
+++ b/CHANGE.rst
@@ -1,6 +1,7 @@
 
 1.3 (unreleased)
 ----------------
+- [#27] - Use WCS objects, instead of the header, to get the pixel scales.
 - [#24] - Allow for `fits.PrimaryHDUs` to be given. Headers are now optional; units default to pixel units in this case. `beamwidth` and `distance` are expected to be `astropy.units.Quantity` objects with appropriate units!
 - [#23] - Fix error in length when using new version of skimage.
 - [#22] - Fix FWHM error calculation.

--- a/fil_finder/__init__.py
+++ b/fil_finder/__init__.py
@@ -4,4 +4,3 @@ __version__ = "1.2.2"
 
 from .analysis import Analysis
 from .filfind_class import fil_finder_2D
-from .width_profiles import filament_profile


### PR DESCRIPTION
As pointed out in #25, all FITS standards were not supported (well actually only one was supported). The angular pixel scales are now accessed through `astropy.wcs.WCS`, alleviating the problem. 