### PR TITLE
Fix Travis failing & support for numpy 1.12

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,9 +20,10 @@ addons:
 env:
     global:
         - SETUP_CMD='test'
-        - CONDA_ADDITIONAL='scipy matplotlib networkx scikit-image h5py'
+        - CONDA_ADDITIONAL='scipy matplotlib networkx h5py'
         - NP_VER=1.10
         - ASTRO_VER=1.0
+        - SKIMG_VER=1.12
     matrix:
         - SETUP_CMD='egg_info'
 
@@ -34,16 +35,22 @@ matrix:
         #   env: SETUP_CMD='build_sphinx -w'
 
         - python: 2.7
-          env: NP_VER=1.9 ASTRO_VER=1.0
+          env: NP_VER=1.9 ASTRO_VER=1.0 SKIMG_VER=1.12
 
         - python: 2.7
-          env: NP_VER=1.10 ASTRO_VER=1.0
+          env: NP_VER=1.10 ASTRO_VER=1.0 SKIMG_VER=1.12
 
         - python: 2.7
-          env: NP_VER=1.10 ASTRO_VER=1.1
+          env: NP_VER=1.10 ASTRO_VER=1.1 SKIMG_VER=1.12
 
         - python: 2.7
-          env: NP_VER=1.11 ASTRO_VER=1.2
+          env: NP_VER=1.11 ASTRO_VER=1.2 SKIMG_VER=1.12
+
+        - python: 2.7
+          env: NP_VER=1.11 ASTRO_VER=1.2 SKIMG_VER=1.12
+
+        - python: 2.7
+          env: NP_VER=1.12 ASTRO_VER=1.3 SKIMG_VER=1.13
 
 before_install:
     - wget http://repo.continuum.io/miniconda/Miniconda-latest-Linux-x86_64.sh -O miniconda.sh
@@ -62,7 +69,7 @@ install:
 
     # Now install dependencies
     - conda install --yes $CONDA_ADDITIONAL
-    - conda install --yes numpy=$NP_VER astropy=$ASTRO_VER
+    - conda install --yes numpy=$NP_VER astropy=$ASTRO_VER scikit-image=$SKIMG_VER
 
 script:
     - python setup.py $SETUP_CMD

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,9 +21,9 @@ env:
     global:
         - SETUP_CMD='test'
         - CONDA_ADDITIONAL='scipy matplotlib networkx h5py'
-        - NP_VER=1.10
-        - ASTRO_VER=1.0
-        - SKIMG_VER=0.12
+        - NP_VER=1.12
+        - ASTRO_VER=1.3
+        - SKIMG_VER=0.13
     matrix:
         - SETUP_CMD='egg_info'
 
@@ -35,13 +35,10 @@ matrix:
         #   env: SETUP_CMD='build_sphinx -w'
 
         - python: 2.7
-          env: NP_VER=1.9 ASTRO_VER=1.0 SKIMG_VER=0.12
+          env: NP_VER=1.10 ASTRO_VER=1.0 SKIMG_VER=0.11
 
         - python: 2.7
-          env: NP_VER=1.10 ASTRO_VER=1.0 SKIMG_VER=0.12
-
-        - python: 2.7
-          env: NP_VER=1.10 ASTRO_VER=1.1 SKIMG_VER=0.12
+          env: NP_VER=1.10 ASTRO_VER=1.1 SKIMG_VER=0.11
 
         - python: 2.7
           env: NP_VER=1.11 ASTRO_VER=1.2 SKIMG_VER=0.12

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@ env:
         - CONDA_ADDITIONAL='scipy matplotlib networkx h5py'
         - NP_VER=1.10
         - ASTRO_VER=1.0
-        - SKIMG_VER=1.12
+        - SKIMG_VER=0.12
     matrix:
         - SETUP_CMD='egg_info'
 
@@ -35,22 +35,22 @@ matrix:
         #   env: SETUP_CMD='build_sphinx -w'
 
         - python: 2.7
-          env: NP_VER=1.9 ASTRO_VER=1.0 SKIMG_VER=1.12
+          env: NP_VER=1.9 ASTRO_VER=1.0 SKIMG_VER=0.12
 
         - python: 2.7
-          env: NP_VER=1.10 ASTRO_VER=1.0 SKIMG_VER=1.12
+          env: NP_VER=1.10 ASTRO_VER=1.0 SKIMG_VER=0.12
 
         - python: 2.7
-          env: NP_VER=1.10 ASTRO_VER=1.1 SKIMG_VER=1.12
+          env: NP_VER=1.10 ASTRO_VER=1.1 SKIMG_VER=0.12
 
         - python: 2.7
-          env: NP_VER=1.11 ASTRO_VER=1.2 SKIMG_VER=1.12
+          env: NP_VER=1.11 ASTRO_VER=1.2 SKIMG_VER=0.12
 
         - python: 2.7
-          env: NP_VER=1.11 ASTRO_VER=1.2 SKIMG_VER=1.12
+          env: NP_VER=1.11 ASTRO_VER=1.2 SKIMG_VER=0.12
 
         - python: 2.7
-          env: NP_VER=1.12 ASTRO_VER=1.3 SKIMG_VER=1.13
+          env: NP_VER=1.12 ASTRO_VER=1.3 SKIMG_VER=0.13
 
 before_install:
     - wget http://repo.continuum.io/miniconda/Miniconda-latest-Linux-x86_64.sh -O miniconda.sh

--- a/fil_finder/filfind_class.py
+++ b/fil_finder/filfind_class.py
@@ -462,16 +462,18 @@ class fil_finder_2D(object):
             ratio = 1
             masking_img = flat_copy
 
-        smooth_img = nd.median_filter(masking_img,
-                                      size=round(self.smooth_size*ratio))
+        smooth_img = \
+            nd.median_filter(masking_img,
+                             size=int(round(self.smooth_size * ratio)))
 
         # Set the border to zeros for the adaptive thresholding. Avoid border
         # effects.
         if zero_border and self.pad_size > 0:
-            smooth_img[:self.pad_size*ratio+1, :] = 0.0
-            smooth_img[-self.pad_size*ratio-1:, :] = 0.0
-            smooth_img[:, :self.pad_size*ratio+1] = 0.0
-            smooth_img[:, -self.pad_size*ratio-1:] = 0.0
+            pad_size = int(self.pad_size * ratio)
+            smooth_img[:pad_size + 1, :] = 0.0
+            smooth_img[-pad_size - 1:, :] = 0.0
+            smooth_img[:, :pad_size + 1] = 0.0
+            smooth_img[:, -pad_size - 1:] = 0.0
 
         adapt = threshold_adaptive(smooth_img,
                                    round_to_odd(ratio * self.adapt_thresh),
@@ -479,7 +481,8 @@ class fil_finder_2D(object):
 
         if regrid:
             regrid_factor = float(regrid_factor)
-            adapt = nd.zoom(adapt, (1/regrid_factor, 1/regrid_factor), order=0)
+            adapt = nd.zoom(adapt, (1 / regrid_factor, 1 / regrid_factor),
+                            order=0)
 
         # Remove areas near the image border
         adapt = adapt * nan_mask
@@ -498,7 +501,7 @@ class fil_finder_2D(object):
         # Remove small holes within the object
 
         if fill_hole_size is None:
-            fill_hole_size = np.pi*(self.beamwidth/self.imgscale)**2
+            fill_hole_size = np.pi * (self.beamwidth / self.imgscale)**2
 
         mask_objs, num, corners = \
             isolateregions(cleaned, fill_hole=True, rel_size=fill_hole_size,

--- a/fil_finder/utilities.py
+++ b/fil_finder/utilities.py
@@ -200,4 +200,4 @@ def in_ipynb():
 
 
 def round_to_odd(x):
-    return (np.ceil((np.ceil(x)/2)+0.5)*2)-1
+    return int((np.ceil((np.ceil(x) / 2) + 0.5) * 2) - 1)


### PR DESCRIPTION
Travis tests were failing since the new scikit-image v0.13 added pywavelets as a dependency, which requires the numpy version to be >1.12.

Also fixed cases where an index is a float, which now raises a `TypeError` in numpy 1.12.