### PR TITLE
Build test py39

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,7 +15,7 @@ jobs:
             name: Python 3.9 with minimal dependencies
             toxenv: py39-test
 
-            - os: ubuntu-latest
+          - os: ubuntu-latest
             python-version: 3.8
             name: Python 3.8 with minimal dependencies
             toxenv: py38-test

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -38,12 +38,12 @@ jobs:
           - os: ubuntu-latest
             python-version: 3.9
             name: Python 3.9, all dependencies, and dev versions of key dependencies
-            toxenv: py38-test-dev
+            toxenv: py39-test-dev
 
           - os: ubuntu-latest
             python-version: 3.9
-            name: Python 398, all dependencies, and coverage
-            toxenv: py38-test-all-cov
+            name: Python 3.9, all dependencies, and coverage
+            toxenv: py39-test-all-cov
 
           - os: macos-latest
             python-version: 3.9

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,29 +11,34 @@ jobs:
       matrix:
         include:
           - os: ubuntu-latest
+            python-version: 3.9
+            name: Python 3.9 with minimal dependencies
+            toxenv: py39-test
+
+            - os: ubuntu-latest
+            python-version: 3.8
+            name: Python 3.8 with minimal dependencies
+            toxenv: py38-test
+
+          - os: ubuntu-latest
             python-version: 3.7
             name: Python 3.7 with minimal dependencies
             toxenv: py37-test
 
           - os: ubuntu-latest
-            python-version: 3.7
-            name: Python 3.7 with minimal and dev dependencies
-            toxenv: py37-test-dev
-
-          - os: ubuntu-18.04
-            python-version: 3.6
-            name: Python 3.6 with minimal and dev dependencies
-            toxenv: py36-test
+            python-version: 3.9
+            name: Python 3.9 with minimal and dev dependencies
+            toxenv: py39-test-dev
 
           - os: ubuntu-latest
-            python-version: 3.8
+            python-version: 3.9
             name: Python 3.8, all dependencies, and dev versions of key dependencies
             toxenv: py38-test-dev
 
           - os: macos-latest
-            python-version: 3.7
-            name: Python 3.7 with all dependencies on MacOS X
-            toxenv: py37-test-all-dev
+            python-version: 3.9
+            name: Python 3.9 with all dependencies on MacOS X
+            toxenv: py39-test-all-dev
 
           # - os: windows-latest
           #   python-version: 3.7
@@ -41,7 +46,7 @@ jobs:
           #   toxenv: py37-test-all-dev
 
           - os: ubuntu-latest
-            python-version: 3.8
+            python-version: 3.9
             name: Documentation
             toxenv: build_docs
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,6 +1,11 @@
 name: Run tests
 
-on: [push, pull_request]
+on:
+  push:
+  pull_request:
+  schedule:
+    - cron: '12 0 * * 1'  # every Monday at 12 pm
+
 
 jobs:
   tests:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -37,8 +37,13 @@ jobs:
 
           - os: ubuntu-latest
             python-version: 3.9
-            name: Python 3.8, all dependencies, and dev versions of key dependencies
+            name: Python 3.9, all dependencies, and dev versions of key dependencies
             toxenv: py38-test-dev
+
+          - os: ubuntu-latest
+            python-version: 3.9
+            name: Python 398, all dependencies, and coverage
+            toxenv: py38-test-all-cov
 
           - os: macos-latest
             python-version: 3.9
@@ -66,6 +71,7 @@ jobs:
     - name: Run tests with ${{ matrix.name }}
       run: tox -v -e ${{ matrix.toxenv }}
     - name: Upload coverage to codecov
+      if: ${{ contains(matrix.toxenv,'-cov') }}
       uses: codecov/codecov-action@v1.0.13
       with:
         file: ./coverage.xml

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,36 @@
+name: Build and upload to PyPI
+
+on: [push, pull_request]
+
+jobs:
+  build_sdist_and_wheel:
+    name: Build source distribution
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-python@v2
+        name: Install Python
+        with:
+          python-version: '3.9'
+      - name: Install build
+        run: python -m pip install build
+      - name: Build sdist
+        run: python -m build --sdist --wheel --outdir dist/ .
+      - uses: actions/upload-artifact@v2
+        with:
+          path: dist/*
+
+  upload_pypi:
+    name: Upload to PyPI
+    needs: [build_sdist_and_wheel]
+    runs-on: ubuntu-latest
+    if: github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags/v')
+    steps:
+      - uses: actions/download-artifact@v2
+        with:
+          name: artifact
+          path: dist
+      - uses: pypa/gh-action-pypi-publish@master
+        with:
+          user: __token__
+          password: ${{ secrets.pypi_password }}

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -34,11 +34,11 @@ Package Dependencies
 
 Requires:
 
- *   numpy >= 1.7.1
+ *   numpy
  *   matplotlib
- *   astropy >= 0.4.0
+ *   astropy
  *   scipy
- *   scikits-image >= 0.8.0
+ *   scikits-image
  *   networkx
 
 Optional:

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -5,16 +5,9 @@ FilFinder can be installed via pip:
 
 >>> pip install fil_finder # doctest: +SKIP
 
-To install from the repository, run:
+To install from the repository, run the following from within the repository folder:
 
->>> python setup.py install # doctest: +SKIP
-
-
-**NOTE:** Due to install conflicts amongst FilFinder's dependencies, installing the package will **NOT** install the dependencies. To check if you have the necessary packages installed, run:
-
->>> python setup.py check_deps # doctest: +SKIP
-
-Unfortunately, this is only available when installing from the repository.
+>>> pip install -e . # doctest: +SKIP
 
 Quickest way to get FilFinder working
 -------------------------------------
@@ -27,7 +20,7 @@ Install the dependencies using:
 >>> conda install --yes numpy scipy matplotlib astropy scikit-image networkx # doctest: +SKIP
 
 This will install all of the newest releases of those packages. FilFinder can then be installed as explained
-above. Test with the ``check_deps`` option if in doubt.
+above.
 
 Package Dependencies
 --------------------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,5 +4,5 @@ requires = ["setuptools",
             "wheel",
             "extension-helpers",
             "oldest-supported-numpy",
-            "cython==0.29.14"]
+            "cython"]
 build-backend = 'setuptools.build_meta'

--- a/setup.cfg
+++ b/setup.cfg
@@ -30,7 +30,6 @@ install_requires =
 test =
     pytest-astropy
     pytest-cov
-    h5py
 docs =
     sphinx-astropy
     sphinx_bootstrap_theme

--- a/setup.cfg
+++ b/setup.cfg
@@ -14,7 +14,7 @@ github_project = e-koch/FilFinder
 [options]
 zip_safe = False
 packages = find:
-python_requires = >=3.6
+python_requires = >=3.7
 setup_requires = setuptools_scm
 install_requires =
     astropy

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist =
-    py{36,37,38}-test{,-all,-dev}
+    py{36,37,38,39}-test{,-all,-dev,-cov}
     build_docs
     codestyle
 requires =
@@ -29,8 +29,9 @@ extras =
     all: all
 commands =
     pip freeze
-    pytest --open-files --pyargs fil_finder {toxinidir}/docs --cov fil_finder --cov-config={toxinidir}/setup.cfg {posargs}
-    coverage xml -o {toxinidir}/coverage.xml
+    !cov: pytest --open-files --pyargs spectral_cube {toxinidir}/docs {posargs}
+    cov: pytest --open-files --pyargs spectral_cube {toxinidir}/docs --cov spectral_cube --cov-config={toxinidir}/setup.cfg {posargs}
+    cov: coverage xml -o {toxinidir}/coverage.xml
 
 [testenv:build_docs]
 changedir =

--- a/tox.ini
+++ b/tox.ini
@@ -29,8 +29,8 @@ extras =
     all: all
 commands =
     pip freeze
-    !cov: pytest --open-files --pyargs spectral_cube {toxinidir}/docs {posargs}
-    cov: pytest --open-files --pyargs spectral_cube {toxinidir}/docs --cov spectral_cube --cov-config={toxinidir}/setup.cfg {posargs}
+    !cov: pytest --open-files --pyargs fil_finder {toxinidir}/docs {posargs}
+    cov: pytest --open-files --pyargs fil_finder {toxinidir}/docs --cov fil_finder --cov-config={toxinidir}/setup.cfg {posargs}
     cov: coverage xml -o {toxinidir}/coverage.xml
 
 [testenv:build_docs]


### PR DESCRIPTION
Updates the testing environments to include python 3.7-3.9.

Also adds wheel creation and upload to pypi as an action.

**Removes python 3.6 support** as our core dependency packages (astropy, numpy) no longer support it.