### PR TITLE
Fix loop case for 3D filaments

### DIFF
--- a/fil_finder/filament.py
+++ b/fil_finder/filament.py
@@ -2230,7 +2230,7 @@ class FilamentPPV(Filament3D, FilamentNDBase):
                 self._internodes = self._internodes[1:]
             # Otherwise it's a perfect loop. Assign the 0th node as the endnode
             else:
-                self._endnodes.append(self._graph[0])
+                self._endnodes.append(list(self._graph.nodes)[0])
 
         # Append the position of each node into the networkx graph
         for node in self._graph:


### PR DESCRIPTION
Fix loop case for 3D filaments by returning the integer index as the end node. Slicing the node from the graph returns an `AtlasView` that raises an error when converting to a set for comparison.